### PR TITLE
Auto connections

### DIFF
--- a/commands/ShowAutoConnectionSettingsCommand.py
+++ b/commands/ShowAutoConnectionSettingsCommand.py
@@ -1,0 +1,20 @@
+from commands.Command import Command
+from ui.dialogs import Dialog, DialogResult
+from ui.DialogFactory import DialogFactory
+from ui.mainwindow_presenter import MainWindowPresenter
+
+class AutoConnectionSettingsCommand(Command):
+    '''Class to handle displaying the trade route creator dialog box'''
+    def __init__(self, mainWindowPresenter: MainWindowPresenter, dialogFactory: DialogFactory):
+        self.__dialogFactory = dialogFactory
+        self.__presenter = mainWindowPresenter
+
+    def execute(self) -> None:
+        '''Runs the dialog and passes results to the presenter and repository'''
+        dialog = self.__dialogFactory.makeAutoConnectionSettingsDialog()
+        result: DialogResult = dialog.show(self.__presenter.config.autoPlanetConnectionDistance, self.__presenter.showAutoConnections)
+
+        if result is DialogResult.Ok:
+            autoConnectionDistance: int = dialog.getDistance()
+            showAutoConnections: bool = dialog.getShowAutoConnections()
+            self.__presenter.onAutoConnectionSettingChanged(autoConnectionDistance, showAutoConnections)

--- a/config.py
+++ b/config.py
@@ -8,6 +8,7 @@ class Config():
         self.__configRoot = et.parse(self.__configFile).getroot()
 
         self.dataPath = self.__configRoot.find("DataPath").text
+        self.autoPlanetConnectionDistance = int(self.__configRoot.find("MaximumFleetMovementDistance").text)
 
         if not self.dataPath:
             self.dataPath = os.getcwd()

--- a/config.xml
+++ b/config.xml
@@ -2,4 +2,5 @@
 
 <Config>
     <DataPath>C:/Program Files (x86)/Steam/SteamApps/common/Star Wars Empire at War/corruption/Mods/Source/Data</DataPath>
+    <MaximumFleetMovementDistance>100</MaximumFleetMovementDistance>
 </Config>

--- a/config.xml
+++ b/config.xml
@@ -2,5 +2,5 @@
 
 <Config>
     <DataPath>C:/Program Files (x86)/Steam/SteamApps/common/Star Wars Empire at War/corruption/Mods/Source/Data</DataPath>
-    <MaximumFleetMovementDistance>100</MaximumFleetMovementDistance>
+    <MaximumFleetMovementDistance>0</MaximumFleetMovementDistance>
 </Config>

--- a/gameObjects/planet.py
+++ b/gameObjects/planet.py
@@ -1,3 +1,4 @@
+from math import sqrt
 '''Planet class definition'''
 
 
@@ -9,6 +10,9 @@ class Planet:
         self.__x: float = 0.0
         self.__y: float = 0.0
         self.__forces: list = []
+    
+    def distanceTo(self, target):
+        return sqrt((self.x - target.x)**2 + (self.y - target.y)**2)
 
     @property
     def name(self) -> str:

--- a/testy.py
+++ b/testy.py
@@ -27,7 +27,7 @@ repository = repositoryCreator.constructRepository(path)
 
 dialogFactory = DialogFactory(repository)
 
-qtMainWindow: QtMainWindow = QtMainWindow()
+qtMainWindow: QtMainWindow = QtMainWindow(config.autoPlanetConnectionDistance)
 presenter: MainWindowPresenter = MainWindowPresenter(qtMainWindow, repository)
 presenter.newTradeRouteCommand = ShowTradeRouteCreatorDialogCommand(presenter, dialogFactory)
 presenter.campaignPropertiesCommand = ShowCampaignCreatorDialogCommand(presenter, dialogFactory)

--- a/testy.py
+++ b/testy.py
@@ -4,6 +4,7 @@ from PyQt5.QtWidgets import QApplication
 
 from commands.ShowTradeCreatorDialogCommand import ShowTradeRouteCreatorDialogCommand
 from commands.ShowCampaignPropertiesDialogCommand import ShowCampaignCreatorDialogCommand
+from commands.ShowAutoConnectionSettingsCommand import AutoConnectionSettingsCommand
 from config import Config
 from ui.DialogFactory import DialogFactory
 from ui.mainwindow_presenter import MainWindow, MainWindowPresenter
@@ -27,11 +28,12 @@ repository = repositoryCreator.constructRepository(path)
 
 dialogFactory = DialogFactory(repository)
 
-qtMainWindow: QtMainWindow = QtMainWindow(config.autoPlanetConnectionDistance)
-presenter: MainWindowPresenter = MainWindowPresenter(qtMainWindow, repository)
+qtMainWindow: QtMainWindow = QtMainWindow()
+presenter: MainWindowPresenter = MainWindowPresenter(qtMainWindow, repository, config)
 presenter.newTradeRouteCommand = ShowTradeRouteCreatorDialogCommand(presenter, dialogFactory)
 presenter.campaignPropertiesCommand = ShowCampaignCreatorDialogCommand(presenter, dialogFactory)
 presenter.planetContextMenu = PlanetContextMenu(presenter)
+presenter.autoConnectionSettingsCommand = AutoConnectionSettingsCommand(presenter, dialogFactory)
 
 qtMainWindow.setMainWindowPresenter(presenter)
 qtMainWindow.getWindow().show()

--- a/ui/DialogFactory.py
+++ b/ui/DialogFactory.py
@@ -1,6 +1,7 @@
 from gameObjects.gameObjectRepository import GameObjectRepository
 from ui.qttraderoutecreator import QtTradeRouteCreator
 from ui.qtcampaignproperties import QtCampaignProperties
+from ui.qtautoconnectionsettings import QtAutoConnectionSettings
 
 class DialogFactory:
     '''Produces dialog boxes'''
@@ -12,3 +13,6 @@ class DialogFactory:
 
     def makeCampaignPropertiesDialog(self) -> QtCampaignProperties:
         return QtCampaignProperties(self.__repository)
+
+    def makeAutoConnectionSettingsDialog(self) -> QtAutoConnectionSettings:
+        return QtAutoConnectionSettings(self.__repository)

--- a/ui/mainwindow_presenter.py
+++ b/ui/mainwindow_presenter.py
@@ -207,7 +207,7 @@ class MainWindowPresenter:
     def onAutoConnectionSettingChanged(self, newAutoConnectionDistance, showAutoConnections):
         self.__config.autoPlanetConnectionDistance = newAutoConnectionDistance
         self.__showAutoConnections = showAutoConnections
-        self.__updateWidgets()
+        self.__updateGalacticPlot()
 
     def onPlanetPositionChanged(self, name, new_x, new_y) -> None:
         '''Updates position of a planet in the repository'''
@@ -221,8 +221,10 @@ class MainWindowPresenter:
         '''Select all planets handler: plots all planets'''
         if checked:
             self.__checkedPlanets.update(self.__planets)
+            self.campaigns[self.__selectedCampaignIndex].planets.update(self.__availableTradeRoutes)
         else:
             self.__checkedPlanets.clear()
+            self.campaigns[self.__selectedCampaignIndex].planets.clear()
 
         self.__mainWindow.updatePlanetComboBox(self.__getNames(self.__checkedPlanets))
         self.__updateAvailableTradeRoutes(self.__checkedPlanets)

--- a/ui/qtautoconnectionsettings.py
+++ b/ui/qtautoconnectionsettings.py
@@ -1,0 +1,71 @@
+from PyQt5 import QtCore
+from PyQt5.QtWidgets import QDialog, QHBoxLayout, QVBoxLayout, QFormLayout, QPushButton, QLineEdit, QCheckBox
+
+from gameObjects.campaign import Campaign
+from gameObjects.gameObjectRepository import GameObjectRepository
+from ui.dialogs import Dialog, DialogResult
+
+class QtAutoConnectionSettings(Dialog):
+    '''Class for a "Auto connections settings" dialog box'''
+    def __init__(self, repository: GameObjectRepository):
+        self.__dialog: QDialog = QDialog()
+        self.__layout: QVBoxLayout = QVBoxLayout()
+        self.__formLayout: QFormLayout = QFormLayout()
+        self.__buttonLayout: QHBoxLayout = QHBoxLayout()
+
+        self.__inputAutoConnectionDistance: QLineEdit = QLineEdit(self.__dialog)
+        self.__toggleAutoConnectionVisibility: QCheckBox = QCheckBox("Hide auto planet connections", self.__dialog)
+
+        self.__okayButton: QPushButton = QPushButton("OK")
+        self.__okayButton.clicked.connect(self.__okayClicked)
+
+        self.__cancelButton: QPushButton = QPushButton("Cancel")
+        self.__cancelButton.clicked.connect(self.__cancelClicked)
+
+        self.__formLayout.addRow("Max distance for planets to auto-connect:", self.__inputAutoConnectionDistance)
+        self.__formLayout.addRow("", self.__toggleAutoConnectionVisibility)
+
+        self.__buttonLayout.addWidget(self.__okayButton)
+        self.__buttonLayout.addWidget(self.__cancelButton)
+
+        self.__layout.addLayout(self.__formLayout)
+        self.__layout.addLayout(self.__buttonLayout)
+
+        self.__dialog.setWindowTitle("Campaign Properties")
+        self.__dialog.setLayout(self.__layout)
+
+        self.__result = DialogResult.Cancel
+
+        self.__repository = repository
+
+        self.__distance: int = 0  #should be config value
+        self.__connectionsVisible = True
+
+    def show(self, currentDistance: int = 0, currentlyVisible: bool = True) -> DialogResult:
+        '''Display dialog modally'''
+        self.__distance = currentDistance
+        self.__inputAutoConnectionDistance.setText(str(self.__distance))
+        self.__toggleAutoConnectionVisibility.setChecked(not currentlyVisible)
+
+        self.__dialog.exec()
+        return self.__result
+
+    def getDistance(self) -> int:
+        '''Returns the required distance for auto connections'''
+        return self.__distance
+
+    def getShowAutoConnections(self) -> bool:
+        '''Returns whether auto connections should be shown'''
+        return self.__connectionsVisible
+
+    def __okayClicked(self) -> None:
+        '''Okay button handler. Performs minor error checking'''
+        self.__distance = int(self.__inputAutoConnectionDistance.text())
+        self.__connectionsVisible = not self.__toggleAutoConnectionVisibility.isChecked()
+
+        self.__result = DialogResult.Ok
+        self.__dialog.close()
+
+    def __cancelClicked(self) -> None:
+        '''Cancel button handler. Closes dialog box'''
+        self.__dialog.close()

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -10,7 +10,7 @@ class QtGalacticPlot(QWidget):
     #signal to send to main window presenter when a planet is selected in the plot
     planetSelectedSignal = pyqtSignal(list)
 
-    def __init__(self, parent: QWidget = None):
+    def __init__(self, parent: QWidget = None, autoPlanetConnectionDistance: int = 0):
         super(QtGalacticPlot, self).__init__()
         self.__galacticPlotWidget: QWidget = QWidget(parent)
         self.__galacticPlotWidget.setLayout(QVBoxLayout())
@@ -29,6 +29,8 @@ class QtGalacticPlot(QWidget):
         self.__annotate.set_visible(False)
         self.__planetNames = []
         self.__planetsScatter = None
+        
+        self.__autoPlanetConnectionDistance: int = autoPlanetConnectionDistance
 
     def plotGalaxy(self, planets, tradeRoutes, allPlanets) -> None:
         '''Plots all planets as alpha = 0.1, then overlays all selected planets and trade routes'''
@@ -62,7 +64,17 @@ class QtGalacticPlot(QWidget):
             x2 = t.end.x
             y2 = t.end.y
             # plot each route (start, end)            
-            self.__axes.plot([x1, x2], [y1, y2], 'k-', alpha=0.3)
+            self.__axes.plot([x1, x2], [y1, y2], 'k-', alpha=0.4)
+        
+        #Create automatic connections between planets
+        if self.__autoPlanetConnectionDistance > 0:
+            for p1 in planets:
+                for p2 in planets:
+                    if p1 == p2:
+                        break
+                    dist: float = p1.distanceTo(p2)
+                    if dist < self.__autoPlanetConnectionDistance:
+                        self.__axes.plot([p1.x, p2.x], [p1.y, p2.y], 'k-', alpha=0.1)
 
         x = []
         y = []

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -10,7 +10,7 @@ class QtGalacticPlot(QWidget):
     #signal to send to main window presenter when a planet is selected in the plot
     planetSelectedSignal = pyqtSignal(list)
 
-    def __init__(self, parent: QWidget = None, autoPlanetConnectionDistance: int = 0):
+    def __init__(self, parent: QWidget = None):
         super(QtGalacticPlot, self).__init__()
         self.__galacticPlotWidget: QWidget = QWidget(parent)
         self.__galacticPlotWidget.setLayout(QVBoxLayout())
@@ -29,10 +29,8 @@ class QtGalacticPlot(QWidget):
         self.__annotate.set_visible(False)
         self.__planetNames = []
         self.__planetsScatter = None
-        
-        self.__autoPlanetConnectionDistance: int = autoPlanetConnectionDistance
 
-    def plotGalaxy(self, planets, tradeRoutes, allPlanets) -> None:
+    def plotGalaxy(self, planets, tradeRoutes, allPlanets, autoPlanetConnectionDistance: int = 0) -> None:
         '''Plots all planets as alpha = 0.1, then overlays all selected planets and trade routes'''
         self.__axes.clear()
 
@@ -67,13 +65,13 @@ class QtGalacticPlot(QWidget):
             self.__axes.plot([x1, x2], [y1, y2], 'k-', alpha=0.4)
         
         #Create automatic connections between planets
-        if self.__autoPlanetConnectionDistance > 0:
+        if autoPlanetConnectionDistance > 0:
             for p1 in planets:
                 for p2 in planets:
                     if p1 == p2:
                         break
                     dist: float = p1.distanceTo(p2)
-                    if dist < self.__autoPlanetConnectionDistance:
+                    if dist < autoPlanetConnectionDistance:
                         self.__axes.plot([p1.x, p2.x], [p1.y, p2.y], 'k-', alpha=0.1)
 
         x = []

--- a/ui/qtmainwindow.py
+++ b/ui/qtmainwindow.py
@@ -15,7 +15,7 @@ from gameObjects.traderoute import TradeRoute
 
 class QtMainWindow(MainWindow):
     '''Qt based window'''
-    def __init__(self, autoPlanetConnectionDistance: int = 0):
+    def __init__(self):
         self.__allPlanetsChecked: bool = False
         self.__allTradeRoutesChecked: bool = False
 
@@ -60,8 +60,12 @@ class QtMainWindow(MainWindow):
 
         #set up menu and menu options
         self.__menuBar: QMenuBar = QMenuBar()
+        self.__optionsMenu: QMenu = QMenu("Options", self.__window)
         self.__fileMenu: QMenu = QMenu("File", self.__window)
         self.__addMenu: QMenu = QMenu("New...", self.__window)
+
+        self.__openAutoConnectionSettingsAction: QAction = QAction("Auto connection settings", self.__window)
+        self.__openAutoConnectionSettingsAction.triggered.connect(self.__showAutoConnectionSettings)
         
         self.__newCampaignAction: QAction = QAction("Galactic Conquest...", self.__window)
         self.__newCampaignAction.triggered.connect(self.__newCampaign)
@@ -78,15 +82,18 @@ class QtMainWindow(MainWindow):
         self.__quitAction: QAction = QAction("Quit", self.__window)
         self.__quitAction.triggered.connect(self.__quit)
         
+        self.__optionsMenu.addAction(self.__openAutoConnectionSettingsAction)
+        
         self.__fileMenu.addAction(self.__saveAction)
         self.__fileMenu.addAction(self.__setDataFolderAction)
         self.__fileMenu.addAction(self.__quitAction)
 
         self.__addMenu.addAction(self.__newCampaignAction)
         self.__addMenu.addAction(self.__newTradeRouteAction)
-
+        
         self.__menuBar.addMenu(self.__fileMenu)
         self.__menuBar.addMenu(self.__addMenu)
+        self.__menuBar.addMenu(self.__optionsMenu)
         self.__window.setMenuWidget(self.__menuBar)
 
         #Set up left pane tabs
@@ -114,8 +121,6 @@ class QtMainWindow(MainWindow):
         self.__startingForces.layout().addWidget(self.__forcesListWidget)
 
         self.__presenter: MainWindowPresenter = None
-        
-        self.__autoPlanetConnectionDistance: int = autoPlanetConnectionDistance
 
     def setMainWindowPresenter(self, presenter: MainWindowPresenter) -> None:
         '''Set the presenter class for the window'''
@@ -141,7 +146,7 @@ class QtMainWindow(MainWindow):
 
     def makeGalacticPlot(self) -> GalacticPlot:
         '''Plot planets and trade routes'''
-        plot: QtGalacticPlot = QtGalacticPlot(self.__widget, self.__autoPlanetConnectionDistance)
+        plot: QtGalacticPlot = QtGalacticPlot(self.__widget)
         self.__widget.addWidget(plot.getWidget())
         return plot
 
@@ -221,6 +226,9 @@ class QtMainWindow(MainWindow):
             checked = True
 
         self.__presenter.onPlanetChecked(item.row(), checked)
+        
+    def __showAutoConnectionSettings(self):
+        self.__presenter.autoConnectionSettingsCommand.execute()
 
     def __showPlanetContextMenu(self, position) -> None:
         self.__presenter.planetContextMenu.show(self.__planetListWidget.itemAt(position), self.__planetListWidget.mapToGlobal(position))

--- a/ui/qtmainwindow.py
+++ b/ui/qtmainwindow.py
@@ -15,7 +15,7 @@ from gameObjects.traderoute import TradeRoute
 
 class QtMainWindow(MainWindow):
     '''Qt based window'''
-    def __init__(self):
+    def __init__(self, autoPlanetConnectionDistance: int = 0):
         self.__allPlanetsChecked: bool = False
         self.__allTradeRoutesChecked: bool = False
 
@@ -114,6 +114,8 @@ class QtMainWindow(MainWindow):
         self.__startingForces.layout().addWidget(self.__forcesListWidget)
 
         self.__presenter: MainWindowPresenter = None
+        
+        self.__autoPlanetConnectionDistance: int = autoPlanetConnectionDistance
 
     def setMainWindowPresenter(self, presenter: MainWindowPresenter) -> None:
         '''Set the presenter class for the window'''
@@ -139,7 +141,7 @@ class QtMainWindow(MainWindow):
 
     def makeGalacticPlot(self) -> GalacticPlot:
         '''Plot planets and trade routes'''
-        plot: QtGalacticPlot = QtGalacticPlot(self.__widget)
+        plot: QtGalacticPlot = QtGalacticPlot(self.__widget, self.__autoPlanetConnectionDistance)
         self.__widget.addWidget(plot.getWidget())
         return plot
 


### PR DESCRIPTION
Added plotting of automatic connections of planets that are close enough. The lines are more transparent thatn for real traderoutes and there is a dialog under the new Options menu to set the distance at which planets should be automatically connected and whether or not the automatic connections should be shown.

Afaik, you don't use the auto connections so I put the default distance in the config to zero.