### PR TITLE
Make planet onhover tooltips render on top

### DIFF
--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -148,5 +148,5 @@ class QtGalacticPlot(QWidget):
         '''Updates annotation parameters'''
         pos = self.__planetsScatter.get_offsets()[ind["ind"][0]]
         self.__annotate.xy = pos
-        text = "{}".format(" ".join([self.__planetNames[n] for n in ind["ind"]]))
+        text = "{}".format("\n".join([self.__planetNames[n] for n in ind["ind"]]))
         self.__annotate.set_text(text)

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -27,7 +27,7 @@ class QtGalacticPlot(QWidget):
         self.__galacticPlotWidget.layout().addWidget(self.__galacticPlotCanvas)
         self.__axes: Axes = self.__galacticPlotCanvas.figure.add_subplot(111, aspect = "equal")
 
-        self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"))
+        self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"), zorder = 9)
         self.__annotate.set_visible(False)
         self.__planetNames = []
         self.__planetsScatter = None
@@ -50,7 +50,7 @@ class QtGalacticPlot(QWidget):
         self.__axes.set_ylim(ylim)
 
         #Has to be set again here for the planet hover labels to work
-        self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"))
+        self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"), zorder = 9)
         self.__annotate.set_visible(False)
 
         self.__planetNames = []


### PR DESCRIPTION
Quick QOL thing to make it easier to read when in a dense part of the map!  Anything above 4 for zorder works here but thought I'd build in some margin in case more layers get added in future!

![image](https://user-images.githubusercontent.com/9806586/236574789-94f0e992-1321-49d8-83a3-67f80edd4960.png)
