### PR TITLE
Fix "Select All" for trade routes and planets

### DIFF
--- a/ui/mainwindow_presenter.py
+++ b/ui/mainwindow_presenter.py
@@ -417,7 +417,7 @@ class MainWindowPresenter:
         """Select all planets handler: plots all planets"""
         if checked:
             self.__checkedPlanets.update(self.__planets)
-            self.getSelectedCampaign().planets.update(self.__availableTradeRoutes)
+            self.getSelectedCampaign().planets.update(self.__planets)
         else:
             self.__checkedPlanets.clear()
             self.getSelectedCampaign().planets.clear()

--- a/ui/qtmainwindow.py
+++ b/ui/qtmainwindow.py
@@ -553,7 +553,7 @@ class QtMainWindow(MainWindow):
         """Checks all rows in a table widget"""
         rowCount = table.rowCount()
         for row in range(rowCount):
-            table.item(row, 0).setCheckState(QtCore.Qt.Checked)
+            table.item(row, 0).setCheckState(QtCore.Qt.CheckState.Checked)
 
     def __uncheckAllTable(self, table: QTableWidget) -> None:
         """Unchecks all rows in a table widget"""


### PR DESCRIPTION
Closes #42
Closes #43 

Note that for the "Select All" on planets, although all planets show as selected in the table widget and the selected planet count above is correct, this doesn't seem to render correctly on the plot (or only does so with some delay, not sure) - but resolving that is outside the scope of this PR!