### PR TITLE
Pass campaignset name into plotGalaxy

### DIFF
--- a/ui/mainwindow_presenter.py
+++ b/ui/mainwindow_presenter.py
@@ -588,6 +588,7 @@ class MainWindowPresenter:
         if not self.__showAutoConnections:
             autoConnectionDistance = 0
         self.__plot.plotGalaxy(
+            self.getSelectedCampaign().setName,
             self.__checkedPlanets,
             self.__checkedTradeRoutes,
             self.__planets,

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -33,7 +33,7 @@ class QtGalacticPlot(QWidget):
         self.__planetOwners = []
         self.__planetsScatter = None
 
-    def plotGalaxy(self, planets, tradeRoutes, allPlanets, planetOwners = [], autoPlanetConnectionDistance: int = 0) -> None:
+    def plotGalaxy(self, campaignSetName, planets, tradeRoutes, allPlanets, planetOwners = [], autoPlanetConnectionDistance: int = 0) -> None:
         '''Plots all planets as alpha = 0.1, then overlays all selected planets and trade routes'''
         if self.__is_first_run:
             x = [p.x for p in allPlanets]
@@ -42,6 +42,8 @@ class QtGalacticPlot(QWidget):
             self.__axes.set_ylim(min(y), max(y))
             
         self.__is_first_run = False
+
+        self.__galacticPlotCanvas.get_default_filename = lambda: campaignSetName + '.png'
 
         xlim = self.__axes.get_xlim()
         ylim = self.__axes.get_ylim()


### PR DESCRIPTION
This allows us to use the campaignset name as the default filename when clicking "Save" on the mathplotlib navigator (i.e. save an image of the plot).  It also means in future we could use the campaignset name in an on-chart title (for example).