### PR TITLE
Improve drawing trade routes on map

### DIFF
--- a/ui/mainwindow_presenter.py
+++ b/ui/mainwindow_presenter.py
@@ -224,25 +224,28 @@ class MainWindowPresenter:
         """If two planets in a row are right clicked by a user, this find and adds the trade route, or helps create a new one"""
         if not self.__onPlotSelectedStartPlanet:
             self.__onPlotSelectedStartPlanet = self.__planets[index]
+            self.__plot.TraceTradeRoute(index, True)
             return
         
         if self.__onPlotSelectedStartPlanet and not self.__onPlotSelectedEndPlanet:
             self.__onPlotSelectedEndPlanet = self.__planets[index]
+            self.__plot.TraceTradeRoute(index, False)
 
         if self.__onPlotSelectedStartPlanet and self.__onPlotSelectedEndPlanet:
-            try:
-                traderoute = self.__repository.getTradeRouteByPlanets(self.__onPlotSelectedStartPlanet, self.__onPlotSelectedEndPlanet)
+            if not self.__onPlotSelectedStartPlanet == self.__onPlotSelectedEndPlanet:
                 try:
-                    index = self.__availableTradeRoutes.index(traderoute)
-                except ValueError:
-                    print("Error, trade route not available but it should be! Try turning a planet off and on")
+                    traderoute = self.__repository.getTradeRouteByPlanets(self.__onPlotSelectedStartPlanet, self.__onPlotSelectedEndPlanet)
+                    try:
+                        index = self.__availableTradeRoutes.index(traderoute)
+                    except ValueError:
+                        print("Error, trade route not available but it should be! Try turning a planet off and on")
 
-                if self.__mainWindow.selectSingleTradeRoute(index):
-                    self.onTradeRouteChecked(index, True)
-                else:
-                    self.onTradeRouteChecked(index, False)
-            except RuntimeError:
-                self.newTradeRouteCommand.execute(start = self.__onPlotSelectedStartPlanet.name, end = self.__onPlotSelectedEndPlanet.name)
+                    if self.__mainWindow.selectSingleTradeRoute(index):
+                        self.onTradeRouteChecked(index, True)
+                    else:
+                        self.onTradeRouteChecked(index, False)
+                except RuntimeError:
+                    self.newTradeRouteCommand.execute(start = self.__onPlotSelectedStartPlanet.name, end = self.__onPlotSelectedEndPlanet.name)
             
             self.__onPlotSelectedStartPlanet = None
             self.__onPlotSelectedEndPlanet = None

--- a/ui/mainwindow_presenter.py
+++ b/ui/mainwindow_presenter.py
@@ -224,12 +224,12 @@ class MainWindowPresenter:
         """If two planets in a row are right clicked by a user, this find and adds the trade route, or helps create a new one"""
         if not self.__onPlotSelectedStartPlanet:
             self.__onPlotSelectedStartPlanet = self.__planets[index]
-            self.__plot.TraceTradeRoute(index, True)
+            self.__plot.TraceTradeRoute(index)
             return
         
         if self.__onPlotSelectedStartPlanet and not self.__onPlotSelectedEndPlanet:
             self.__onPlotSelectedEndPlanet = self.__planets[index]
-            self.__plot.TraceTradeRoute(index, False)
+            self.__plot.TraceTradeRoute(None)
 
         if self.__onPlotSelectedStartPlanet and self.__onPlotSelectedEndPlanet:
             if not self.__onPlotSelectedStartPlanet == self.__onPlotSelectedEndPlanet:

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -56,7 +56,6 @@ class QtGalacticPlot(QWidget):
 
         self.__horizontal_line = self.__axes.axhline(color='m', lw=0.8, ls='--')
         self.__vertical_line = self.__axes.axvline(color='m', lw=0.8, ls='--')
-        #self.__tradeRouteTrace = self.__axes.plot([1000,-500], [1000,0], color='y', lw=0.8, ls='--')
         self.__horizontal_line.set_visible(False)
         self.__vertical_line.set_visible(False)
 
@@ -148,6 +147,7 @@ class QtGalacticPlot(QWidget):
 
         if event.inaxes == self.__axes:
 
+            '''Add tracing lines when drawing Trade Routes'''
             if self.__horizontal_line.get_visible():
                 start = self.__tradeRouteTraceStart
                 startpos = self.__planetsScatter.get_offsets()[start]
@@ -162,6 +162,7 @@ class QtGalacticPlot(QWidget):
                 self.__tradeRouteTrace = self.__axes.plot([0,0], [0,0])
                 self.__galacticPlotCanvas.draw_idle()
 
+            '''Display annotation tooltip if the cursor is over a planet'''
             if self.__planetsScatter:
                 contains, ind = self.__planetsScatter.contains(event)
             else:

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -32,6 +32,7 @@ class QtGalacticPlot(QWidget):
         self.__planetNames = []
         self.__planetOwners = []
         self.__planetsScatter = None
+        self.__tradeRouteTraceStart = None
 
     def plotGalaxy(self, planets, tradeRoutes, allPlanets, planetOwners = [], autoPlanetConnectionDistance: int = 0) -> None:
         '''Plots all planets as alpha = 0.1, then overlays all selected planets and trade routes'''
@@ -53,11 +54,6 @@ class QtGalacticPlot(QWidget):
         #Has to be set again here for the planet hover labels to work
         self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"), zorder = 9)
         self.__annotate.set_visible(False)
-
-        self.__horizontal_line = self.__axes.axhline(color='m', lw=0.8, ls='--')
-        self.__vertical_line = self.__axes.axvline(color='m', lw=0.8, ls='--')
-        self.__horizontal_line.set_visible(False)
-        self.__vertical_line.set_visible(False)
 
         self.__planetNames = []
         self.__planetOwners = []
@@ -148,19 +144,13 @@ class QtGalacticPlot(QWidget):
         if event.inaxes == self.__axes:
 
             '''Add tracing lines when drawing Trade Routes'''
-            if self.__horizontal_line.get_visible():
-                start = self.__tradeRouteTraceStart
-                startpos = self.__planetsScatter.get_offsets()[start]
-                startx, starty = startpos[0], startpos[1]
-                x, y = event.xdata, event.ydata
-                self.__horizontal_line.set_ydata([y])
-                self.__vertical_line.set_xdata([x])
+            if not self.__tradeRouteTraceStart == None:
+                startpos = self.__planetsScatter.get_offsets()[self.__tradeRouteTraceStart]
                 self.__axes.lines.remove(self.__tradeRouteTrace[0])
-                self.__tradeRouteTrace = self.__axes.plot([startx,x], [starty,y], color='y', lw=0.8, ls='--')
+                self.__tradeRouteTrace = self.__axes.plot([startpos[0],event.xdata], [startpos[1],event.ydata], color='y', lw=0.8, ls='--')
                 self.__galacticPlotCanvas.draw_idle()
-            else:
+            else :
                 self.__tradeRouteTrace = self.__axes.plot([0,0], [0,0])
-                self.__galacticPlotCanvas.draw_idle()
 
             '''Display annotation tooltip if the cursor is over a planet'''
             if self.__planetsScatter:
@@ -184,9 +174,7 @@ class QtGalacticPlot(QWidget):
         text = "\n".join("{} [{}]".format(self.__planetNames[n], self.__planetOwners[n]) for n in ind["ind"])
         self.__annotate.set_text(text)
 
-    def TraceTradeRoute(self, ind, visible) -> None:
+    def TraceTradeRoute(self, ind) -> None:
         '''Handler for tracing a traderoute between planets on plot'''
         '''Trace movement is handled in __planetHover'''
-        self.__horizontal_line.set_visible(visible)
-        self.__vertical_line.set_visible(visible)
         self.__tradeRouteTraceStart = ind

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -54,6 +54,12 @@ class QtGalacticPlot(QWidget):
         self.__annotate = self.__axes.annotate("", xy = (0,0), xytext = (10, 10), textcoords = "offset points", bbox = dict(boxstyle="round", fc="w"), arrowprops = dict(arrowstyle="->"), zorder = 9)
         self.__annotate.set_visible(False)
 
+        self.__horizontal_line = self.__axes.axhline(color='m', lw=0.8, ls='--')
+        self.__vertical_line = self.__axes.axvline(color='m', lw=0.8, ls='--')
+        #self.__tradeRouteTrace = self.__axes.plot([1000,-500], [1000,0], color='y', lw=0.8, ls='--')
+        self.__horizontal_line.set_visible(False)
+        self.__vertical_line.set_visible(False)
+
         self.__planetNames = []
         self.__planetOwners = []
 
@@ -141,6 +147,21 @@ class QtGalacticPlot(QWidget):
         visible = self.__annotate.get_visible()
 
         if event.inaxes == self.__axes:
+
+            if self.__horizontal_line.get_visible():
+                start = self.__tradeRouteTraceStart
+                startpos = self.__planetsScatter.get_offsets()[start]
+                startx, starty = startpos[0], startpos[1]
+                x, y = event.xdata, event.ydata
+                self.__horizontal_line.set_ydata([y])
+                self.__vertical_line.set_xdata([x])
+                self.__axes.lines.remove(self.__tradeRouteTrace[0])
+                self.__tradeRouteTrace = self.__axes.plot([startx,x], [starty,y], color='y', lw=0.8, ls='--')
+                self.__galacticPlotCanvas.draw_idle()
+            else:
+                self.__tradeRouteTrace = self.__axes.plot([0,0], [0,0])
+                self.__galacticPlotCanvas.draw_idle()
+
             if self.__planetsScatter:
                 contains, ind = self.__planetsScatter.contains(event)
             else:
@@ -161,3 +182,10 @@ class QtGalacticPlot(QWidget):
         self.__annotate.xy = pos
         text = "\n".join("{} [{}]".format(self.__planetNames[n], self.__planetOwners[n]) for n in ind["ind"])
         self.__annotate.set_text(text)
+
+    def TraceTradeRoute(self, ind, visible) -> None:
+        '''Handler for tracing a traderoute between planets on plot'''
+        '''Trace movement is handled in __planetHover'''
+        self.__horizontal_line.set_visible(visible)
+        self.__vertical_line.set_visible(visible)
+        self.__tradeRouteTraceStart = ind

--- a/ui/qtgalacticplot.py
+++ b/ui/qtgalacticplot.py
@@ -148,7 +148,6 @@ class QtGalacticPlot(QWidget):
                 startpos = self.__planetsScatter.get_offsets()[self.__tradeRouteTraceStart]
                 self.__axes.lines.remove(self.__tradeRouteTrace[0])
                 self.__tradeRouteTrace = self.__axes.plot([startpos[0],event.xdata], [startpos[1],event.ydata], color='y', lw=0.8, ls='--')
-                self.__galacticPlotCanvas.draw_idle()
             else :
                 self.__tradeRouteTrace = self.__axes.plot([0,0], [0,0])
 
@@ -161,11 +160,11 @@ class QtGalacticPlot(QWidget):
             if contains:
                 self.__update_annotation(ind)
                 self.__annotate.set_visible(True)
-                self.__galacticPlotCanvas.draw_idle()
             else:
                 if visible:
                     self.__annotate.set_visible(False)
-                    self.__galacticPlotCanvas.draw_idle()
+            
+            self.__galacticPlotCanvas.draw_idle()
 
     def __update_annotation(self, ind) -> None:
         '''Updates annotation parameters'''


### PR DESCRIPTION
Contributes to #57.

- After right-clicking a planet on the plot and activating the "draw trade route" function:
  - A trace line is drawn from that planet to the cursor
  - ~~A crosshairs is drawn around the cursor~~ (Removed)
- These remain active until the "drawn" trade route is completed (by right clicking on another planet) or cancelled (by right clicking on the starting planet).

- Right clicking on the same planet twice in a row now cancels the "draw trade route" (as mentioned above) rather than launching the "new trade route" dialog with the same start and end locations.
- The "new trade route" dialog from the menu bar has **NOT** been updated and may still permit routes to be created with the same start and end locations.

![image](https://github.com/andrewfullard/PyGCEditor/assets/9806586/e2e80d6c-6a16-40da-a91f-99216dbfbb57)
